### PR TITLE
support ubuntu22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 | 🌐 ブラウザ版 | Python不要の軽量版、OBSで直接使用可能 |
 | 🎬 複数動画切り替え | 複数モーションをボタンで瞬時に切替 |
 | 🍎 macOS対応 | Apple Silicon (M1/M2/M3/M4) で動作 |
+| 🐧 Ubuntu対応 | Ubuntu 22.04 LTS (x86_64, CUDA) で動作 |
 
 ---
 
@@ -32,6 +33,7 @@
 - [インストール](#-インストール)
   - [Windows](#windows)
   - [macOS (実験的)](#macos-実験的)
+  - [Ubuntu (実験的)](#ubuntu-実験的)
 - [使い方](#-使い方)
   - [メインGUI](#メインgui)
   - [ブラウザ版プレイヤー](#-ブラウザ版プレイヤー)
@@ -152,6 +154,50 @@ uv pip install mmdet==2.28.0 mmpose==0.29.0
 
 </details>
 
+### Ubuntu (実験的)
+
+<details>
+<summary><b>クリックして展開（Ubuntu 22.04 LTS, x86_64, NVIDIA GPU）</b></summary>
+
+#### 1. 前提条件
+
+- Ubuntu 22.04 LTS (x86_64)
+- NVIDIA GPU + CUDA 11.7 対応ドライバ (確認済み : 570.172.08)
+- uv:
+  ```bash
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  ```
+
+#### 2. システムパッケージ
+
+```bash
+sudo apt-get install -y libportaudio2
+```
+
+#### 3. インストール
+
+```bash
+uv sync
+```
+
+#### 4. 確認
+
+```bash
+uv run python -c "import cv2; import torch; print('OK')"
+```
+
+#### 5. 起動
+
+```bash
+uv run python mouth_track_gui.py
+```
+
+#### 注意事項
+
+- **オーディオデバイス**: USB マイク等が sounddevice のデバイス一覧に表示されない場合があります。PulseAudio 経由で自動補完されるため、GUI のデバイス一覧で `pa:...  (via pulse)` と表示されるデバイスを選択してください。
+
+</details>
+
 ---
 
 ## 🎮 使い方
@@ -269,8 +315,9 @@ MotionPNGTuber/
 ├── convert_npz_to_json.py          # npz→JSON変換
 ├── lipsync_core.py                 # 共通モジュール
 ├── MotionPNGTuber_Player/          # ブラウザ版
-├── pyproject.toml                  # 依存関係（Windows）
+├── pyproject.toml                  # 依存関係（Windows / Ubuntu）
 ├── pyproject.macos.toml            # 依存関係（macOS）
+├── audio_linux.py                  # Linux オーディオ補助
 └── mouth_dir/                      # 口スプライト
 ```
 

--- a/audio_linux.py
+++ b/audio_linux.py
@@ -1,0 +1,227 @@
+"""
+audio_linux.py
+
+Linux (PulseAudio) 固有のオーディオデバイス補助。
+PortAudio (ALSA backend) が USB デバイスを個別列挙しない問題を
+PulseAudio 経由で補完する。
+
+他の OS では全関数が no-op として安全に呼び出せる。
+"""
+
+from __future__ import annotations
+
+import platform
+import subprocess
+
+
+def is_linux() -> bool:
+    return platform.system() == "Linux"
+
+
+# ---------------------------------------------------------------------------
+# PulseAudio ソース列挙
+# ---------------------------------------------------------------------------
+
+def list_pulse_input_sources() -> list[str]:
+    """PulseAudio の入力ソース名一覧を返す (.monitor を除く)。"""
+    if not is_linux():
+        return []
+    try:
+        out = subprocess.check_output(
+            ["pactl", "list", "sources", "short"],
+            text=True, timeout=5,
+        )
+    except Exception:
+        return []
+    sources = []
+    for line in out.strip().splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2:
+            name = parts[1]
+            if ".monitor" not in name:
+                sources.append(name)
+    return sources
+
+
+def set_pulse_default_source(pa_name: str) -> bool:
+    """PulseAudio のデフォルト入力ソースを設定する。成功なら True。"""
+    if not is_linux():
+        return False
+    try:
+        subprocess.check_call(
+            ["pactl", "set-default-source", pa_name], timeout=5,
+        )
+        print(f"[audio/linux] set PulseAudio default source -> {pa_name}")
+        return True
+    except Exception as e:
+        print(f"[audio/linux] warning: failed to set default source: {e}")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# sounddevice デバイス index ヘルパー
+# ---------------------------------------------------------------------------
+
+def _find_sd_device_index(sd, name: str) -> int | None:
+    """sounddevice デバイス一覧から名前が一致する入力デバイスの index を返す。"""
+    try:
+        for i, dev in enumerate(sd.query_devices()):
+            if dev.get("name") == name and dev.get("max_input_channels", 0) > 0:
+                return i
+    except Exception:
+        pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# デバイス解決 (ランタイム用)
+# ---------------------------------------------------------------------------
+
+def prepare_device(device_int: int | None, sd) -> int | None:
+    """デバイス index を検証し、Linux で無効なら PulseAudio 経由の index に置き換えて返す。
+
+    - Linux 以外、または index が有効 → そのまま返す
+    - Linux で index が無効 → PulseAudio フォールバックを試み、
+      成功すれば pulse デバイスの index を返す
+    - フォールバックも失敗 → 元の値をそのまま返す
+    """
+    if not is_linux():
+        return device_int
+    if device_int is None:
+        return device_int
+
+    # デバイス index が有効か確認
+    try:
+        dev = sd.query_devices(device_int, "input")
+        if dev.get("max_input_channels", 0) > 0:
+            return device_int
+    except Exception:
+        pass
+
+    # 無効 → PulseAudio フォールバック
+    fallback = _resolve_via_pulse(sd)
+    return fallback if fallback is not None else device_int
+
+
+def _resolve_via_pulse(sd) -> int | None:
+    """PulseAudio の最初の入力ソースをデフォルトに設定し、pulse デバイス index を返す。"""
+    if not is_linux():
+        return None
+
+    sources = list_pulse_input_sources()
+    if not sources:
+        return None
+
+    # 最初の PulseAudio 入力ソースをデフォルトに設定
+    set_pulse_default_source(sources[0])
+    pulse_idx = _find_sd_device_index(sd, "pulse")
+    if pulse_idx is not None:
+        print(f"[audio/linux] fallback -> pulse device #{pulse_idx} ({sources[0]})")
+        return pulse_idx
+
+    default_idx = _find_sd_device_index(sd, "default")
+    if default_idx is not None:
+        print(f"[audio/linux] fallback -> default device #{default_idx} ({sources[0]})")
+        return default_idx
+
+    return None
+
+
+def resolve_device_by_name(name_query: str, sd) -> int | None:
+    """デバイス名 (部分一致) で PulseAudio ソースを検索・設定し、
+    sounddevice の pulse デバイス index を返す。
+
+    見つからなければ None。
+    """
+    if not is_linux():
+        return None
+
+    # まず sounddevice 側で名前一致を探す
+    try:
+        for i, dev in enumerate(sd.query_devices()):
+            if dev.get("max_input_channels", 0) > 0:
+                if name_query.lower() in dev["name"].lower():
+                    print(f"[audio/linux] matched sounddevice #{i}: {dev['name']}")
+                    return i
+    except Exception:
+        pass
+
+    # PulseAudio ソースから検索
+    for pa_name in list_pulse_input_sources():
+        if name_query.lower() in pa_name.lower():
+            print(f"[audio/linux] matched PulseAudio source: {pa_name}")
+            set_pulse_default_source(pa_name)
+            pulse_idx = _find_sd_device_index(sd, "pulse")
+            if pulse_idx is not None:
+                return pulse_idx
+            return _find_sd_device_index(sd, "default")
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# GUI デバイスリスト拡張
+# ---------------------------------------------------------------------------
+
+def add_device_list_linux(devices: list, sd) -> list:
+    """既存のデバイスリストに PulseAudio 入力ソースを追加して返す。
+
+    devices: [(index, display_string), ...] 形式。
+    sounddevice に既に列挙されているソースは追加しない。
+    """
+    if not is_linux():
+        return devices
+
+    pulse_idx = _find_sd_device_index(sd, "pulse")
+    if pulse_idx is None:
+        return devices
+
+    # 既存デバイス名を収集 (重複排除用)
+    existing_names = set()
+    for _, disp in devices:
+        existing_names.add(disp.lower())
+
+    for pa_name in list_pulse_input_sources():
+        # 既に sounddevice 側の表示名に含まれている場合はスキップ
+        if any(pa_name.lower() in n for n in existing_names):
+            continue
+        devices.append((pulse_idx, f"pa:{pa_name}  (via pulse)"))
+
+    return devices
+
+
+def add_audio_device_linux_str(devices: list[str], sd) -> list[str]:
+    """文字列リスト版の add_device_list_linux (multi_video_live_gui 用)。"""
+    if not is_linux():
+        return devices
+
+    pulse_idx = _find_sd_device_index(sd, "pulse")
+    if pulse_idx is None:
+        return devices
+
+    existing_lower = {d.lower() for d in devices}
+
+    for pa_name in list_pulse_input_sources():
+        if any(pa_name.lower() in n for n in existing_lower):
+            continue
+        devices.append(f"pa:{pa_name}  (via pulse)")
+
+    return devices
+
+
+# ---------------------------------------------------------------------------
+# GUI デバイス選択ハンドラ
+# ---------------------------------------------------------------------------
+
+def handle_pa_device_selection(device_str: str, sd) -> int | None:
+    """'pa:<source_name>  (via pulse)' 形式のデバイス文字列を処理する。
+
+    PulseAudio のデフォルトソースを設定し、pulse デバイスの index を返す。
+    pa: 形式でなければ None を返す (= 通常処理に委譲)。
+    """
+    if not device_str.startswith("pa:"):
+        return None
+
+    pa_name = device_str[3:].split("  (via pulse)")[0].strip()
+    set_pulse_default_source(pa_name)
+    return _find_sd_device_index(sd, "pulse")

--- a/loop_lipsync_runtime_patched_emotion_auto.py
+++ b/loop_lipsync_runtime_patched_emotion_auto.py
@@ -302,6 +302,10 @@ def run(args) -> None:
     # ---- audio device ----
     samplerate = 48000
     input_channels = 1
+    # Linux: 無効なデバイス index を PulseAudio 経由で補正
+    from audio_linux import prepare_device
+    args.device = prepare_device(args.device, sd)
+
     if args.device is not None:
         dev = sd.query_devices(args.device, "input")
         samplerate = int(dev["default_samplerate"])

--- a/mouth_track_gui.py
+++ b/mouth_track_gui.py
@@ -87,6 +87,9 @@ def _try_list_input_devices() -> list[tuple[int, str]]:
                 ch = int(d.get("max_input_channels", 0))
                 sr = int(float(d.get("default_samplerate", 0)) or 0)
                 devices.append((i, f"{i}: {name}  (ch={ch}, sr={sr})"))
+        # Linux: PulseAudio 入力ソースを追加
+        from audio_linux import add_device_list_linux
+        devices = add_device_list_linux(devices, sd)
         return devices
     except Exception:
         return []
@@ -627,6 +630,14 @@ class App(tk.Tk):
 
         def _on_select(_evt=None):
             s = self.audio_device_menu_var.get()
+            # Linux: PulseAudio デバイス (pa:...) の処理
+            from audio_linux import handle_pa_device_selection
+            import sounddevice as _sd
+            pa_idx = handle_pa_device_selection(s, _sd)
+            if pa_idx is not None:
+                self.audio_device_var.set(pa_idx)
+                save_session({"audio_device": s})
+                return
             try:
                 n = int(s.split(":", 1)[0].strip())
                 self.audio_device_var.set(n)

--- a/multi_video_live_gui.py
+++ b/multi_video_live_gui.py
@@ -1793,6 +1793,10 @@ class MultiVideoLiveApp(tk.Tk):
         except Exception as e:
             self._log(f"オーディオデバイス取得エラー: {e}")
 
+        # Linux: PulseAudio 入力ソースを追加
+        from audio_linux import add_audio_device_linux_str
+        devices = add_audio_device_linux_str(devices, sd)
+
         self.audio_combo["values"] = devices
         if devices and not self.audio_device_var.get():
             self.audio_device_var.set(devices[0])
@@ -2086,7 +2090,13 @@ class MultiVideoLiveApp(tk.Tk):
         try:
             audio_str = self.audio_device_var.get()
             if audio_str:
-                audio_device = int(audio_str.split(":")[0])
+                # Linux: PulseAudio デバイス (pa:...) の処理
+                from audio_linux import handle_pa_device_selection
+                pa_idx = handle_pa_device_selection(audio_str, sd)
+                if pa_idx is not None:
+                    audio_device = pa_idx
+                else:
+                    audio_device = int(audio_str.split(":")[0])
         except Exception:
             pass
         if audio_device is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,10 @@ dependencies = [
 ]
 
 [tool.uv]
+environments = [
+    "sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "sys_platform == 'win32' and platform_machine == 'AMD64'",
+]
 override-dependencies = [
     # headless版を無効化してGUI版のopencv-pythonを使用
     "opencv-python-headless>=4.5.4.58 ; sys_platform == 'never'",
@@ -32,7 +36,10 @@ extra-index-url = [
 index-strategy = "unsafe-best-match"
 
 [tool.uv.sources]
-mmcv-full = { url = "https://download.openmmlab.com/mmcv/dist/cu117/torch1.13.0/mmcv_full-1.7.0-cp310-cp310-win_amd64.whl" }
+mmcv-full = [
+    { url = "https://download.openmmlab.com/mmcv/dist/cu117/torch1.13.0/mmcv_full-1.7.0-cp310-cp310-manylinux1_x86_64.whl", marker = "sys_platform == 'linux'" },
+    { url = "https://download.openmmlab.com/mmcv/dist/cu117/torch1.13.0/mmcv_full-1.7.0-cp310-cp310-win_amd64.whl", marker = "sys_platform == 'win32'" },
+]
 
 [tool.uv.extra-build-dependencies]
 chumpy = ["wheel", "pip", "setuptools"]


### PR DESCRIPTION
素晴らしいツールを公開してくださりありがとうございます。
私は主にロボット分野でのソフトウェア開発に取り組んでいますが、このツールに大きな可能性を感じています。

ロボット分野ではLinux (主にubuntu) を使用するため、ubuntu22.04向けの対応追加を希望します。

## 主な変更点

- audio_linux.py の追加 : Linux環境では現在の実装ではオーディオ入力では出現しないため、PulseAudio経由でデバイスの補完を行います。非Linux（is_linux()でfalseが返ってきたとき）の場合は何もしません。
-  pyproject.toml のUbuntu対応 : mmcv のパスをWIndowsと区別するための設定とURL指定を追加しました。オプションは変更せず、uv側のOS検出で切り替わります。（Windows側の検証はしていません)

今後のツールの発展を応援しています 🙂🚀