### PR TITLE
fix: prevent mouth sprite bouncing and add hysteresis to lip level detection

### DIFF
--- a/lipsync_core.py
+++ b/lipsync_core.py
@@ -547,14 +547,16 @@ def load_mouth_sprites(mouth_dir: str, full_w: int, full_h: int) -> dict[str, np
         else:
             sx, sy = 1.00, 1.00
 
-        rw = max(2, int(round(w * sx)))
-        rh = max(2, int(round(h * sy)))
+        rw = max(2, min(int(round(w * sx)), w))  # clamp to canvas width
+        rh = max(2, min(int(round(h * sy)), h))  # clamp to canvas height
         small = cv2.resize(open_rgba, (rw, rh), interpolation=cv2.INTER_AREA)
 
         canvas = np.zeros((h, w, 4), dtype=np.uint8)
-        x0 = (w - rw) // 2
-        y0 = h - rh
-        canvas[y0:y0 + rh, x0:x0 + rw] = small
+        x0 = max(0, (w - rw) // 2)
+        y0 = max(0, (h - rh) // 2)  # center vertically to prevent bouncing
+        paste_w = min(rw, w - x0)
+        paste_h = min(rh, h - y0)
+        canvas[y0:y0 + paste_h, x0:x0 + paste_w] = small[:paste_h, :paste_w]
 
         if key == "closed":
             canvas[..., 3] = (canvas[..., 3].astype(np.float32) * 0.85).astype(np.uint8)

--- a/loop_lipsync_runtime_patched_emotion_auto.py
+++ b/loop_lipsync_runtime_patched_emotion_auto.py
@@ -714,13 +714,29 @@ def run(args) -> None:
                             U_TH = float(np.percentile(cent_open, 20))
                             E_TH = float(np.percentile(cent_open, 80))
 
-                # mouth level
-                if env < HALF_TH:
-                    mouth_level = "closed"
-                elif env < OPEN_TH:
-                    mouth_level = "half"
-                else:
-                    mouth_level = "open"
+                # mouth level (with hysteresis deadband to prevent bouncing)
+                _deadband = 0.04
+                if not hasattr(run, '_prev_mouth_level'):
+                    run._prev_mouth_level = "closed"
+                _pml = run._prev_mouth_level
+                if _pml == "closed":
+                    if env >= HALF_TH + _deadband:
+                        mouth_level = "half" if env < OPEN_TH else "open"
+                    else:
+                        mouth_level = "closed"
+                elif _pml == "half":
+                    if env < HALF_TH - _deadband:
+                        mouth_level = "closed"
+                    elif env >= OPEN_TH + _deadband:
+                        mouth_level = "open"
+                    else:
+                        mouth_level = "half"
+                else:  # open
+                    if env < OPEN_TH - _deadband:
+                        mouth_level = "half" if env >= HALF_TH else "closed"
+                    else:
+                        mouth_level = "open"
+                run._prev_mouth_level = mouth_level
 
                 # vowel selection on peaks
                 if mouth_level == "open":
@@ -763,9 +779,12 @@ def run(args) -> None:
             # ---- preview ----
             frp = vid_prev.get_frame(now).copy()
             draw_one(frp, vid_prev.frame_idx, track_prev, args.preview_scale)
-            cv2.imshow(window_name, cv2.cvtColor(frp, cv2.COLOR_RGB2BGR))
-            if cv2.waitKey(1) & 0xFF == ord("q"):
-                break
+            try:
+                cv2.imshow(window_name, cv2.cvtColor(frp, cv2.COLOR_RGB2BGR))
+                if cv2.waitKey(1) & 0xFF == ord("q"):
+                    break
+            except cv2.error:
+                pass  # suppress GIL race condition with audio thread on macOS
 
             # ---- virtual cam ----
             if cam is not None and vid_full is not None:


### PR DESCRIPTION
## Summary
Fix visual jitter/bouncing of mouth sprite and unstable lip level transitions.

## Changes

### `lipsync_core.py` — Sprite rendering fix
- Clamp resized sprite dimensions to canvas bounds (`min(rw, w)`, `min(rh, h)`)
- Center sprite vertically instead of bottom-aligning to reduce visual jitter
- Add boundary checks when pasting sprite onto canvas to prevent array overflow

### `loop_lipsync_runtime_patched_emotion_auto.py` — Hysteresis + stability
- Add hysteresis deadband (4%) to mouth level transitions (closed ↔ half ↔ open) to prevent rapid flickering at threshold boundaries
- Guard `cv2.imshow` with `cv2.error` catch for GIL race conditions with the audio thread on macOS

## Motivation
When the mouth opening value fluctuates near the threshold (e.g., between "closed" and "half"), the sprite rapidly switches states every frame, causing visible jitter. The hysteresis deadband requires the value to cross a slightly higher/lower threshold before transitioning, smoothing the animation.

The sprite clamping fix prevents the resized mouth image from exceeding canvas dimensions, which could cause numpy array index errors.

## Testing
Tested on macOS 14 (Apple Silicon M4). These changes are platform-independent and should benefit all environments.